### PR TITLE
fix(windows): copy all necessary executable and DLL files

### DIFF
--- a/gnuplot_wheel/build.py
+++ b/gnuplot_wheel/build.py
@@ -67,7 +67,7 @@ class GnuplotBuild(build_py):
             # Copy gnuplot.exe and all DLL files
             files_copied = 0
             for file in os.listdir(gnuplot_bin_dir):
-                if file.endswith((".exe", ".dll")):
+                if file.lower().endswith((".exe", ".dll")):
                     src = os.path.join(gnuplot_bin_dir, file)
                     dst = os.path.join(install_dir, file)
                     shutil.copy(src, dst)

--- a/gnuplot_wheel/build.py
+++ b/gnuplot_wheel/build.py
@@ -54,15 +54,32 @@ class GnuplotBuild(build_py):
             with zipfile.ZipFile(zip_path, "r") as zip_ref:
                 zip_ref.extractall(tmpdir)
 
-            # Find and copy gnuplot.exe
+            # Find the bin directory containing gnuplot.exe and all DLLs
+            gnuplot_bin_dir = None
             for root, dirs, files in os.walk(tmpdir):
                 if "gnuplot.exe" in files:
-                    src = os.path.join(root, "gnuplot.exe")
-                    shutil.copy(src, install_dir)
-                    print(f"Copied gnuplot.exe to {install_dir}")
-                    return
+                    gnuplot_bin_dir = root
+                    break
 
-            raise RuntimeError("Could not find gnuplot.exe in downloaded archive")
+            if not gnuplot_bin_dir:
+                raise RuntimeError("Could not find gnuplot.exe in downloaded archive")
+
+            # Copy gnuplot.exe and all DLL files
+            files_copied = 0
+            for file in os.listdir(gnuplot_bin_dir):
+                if file.endswith((".exe", ".dll")):
+                    src = os.path.join(gnuplot_bin_dir, file)
+                    dst = os.path.join(install_dir, file)
+                    shutil.copy(src, dst)
+                    files_copied += 1
+                    print(f"Copied {file} to {install_dir}")
+
+            if files_copied == 0:
+                raise RuntimeError("No executable or DLL files found")
+
+            print(
+                f"Successfully copied {files_copied} files (gnuplot.exe and dependencies)"
+            )
 
     def _build_unix(self, install_dir):
         """Build gnuplot from source on Unix-like systems."""

--- a/gnuplot_wheel/build.py
+++ b/gnuplot_wheel/build.py
@@ -75,7 +75,7 @@ class GnuplotBuild(build_py):
                     print(f"Copied {file} to {install_dir}")
 
             if files_copied == 0:
-                raise RuntimeError("No executable or DLL files found")
+                raise RuntimeError(f"No .exe or .dll files found in {gnuplot_bin_dir}")
 
             print(
                 f"Successfully copied {files_copied} files (gnuplot.exe and dependencies)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ local_scheme = "no-local-version"
 fallback_version = "6.0.0"
 
 [tool.setuptools.package-data]
-gnuplot_wheel = ["bin/gnuplot", "bin/gnuplot.exe"]
+gnuplot_wheel = ["bin/gnuplot", "bin/*.exe", "bin/*.dll"]
 
 [tool.cibuildwheel]
 build-verbosity = 1


### PR DESCRIPTION
Enhance the Windows build process to copy all necessary executable and DLL files